### PR TITLE
Improve Chase Credit Parsing

### DIFF
--- a/src/parsers/chase-credit-card-parser.ts
+++ b/src/parsers/chase-credit-card-parser.ts
@@ -96,12 +96,12 @@ function nextState(currentState: State, line: string): State {
         case State.HEADER:
             if (line === 'payments and other credits') {
                 return State.PAYMENT;
-            } else if (line === 'purchase') {
+            } else if (line === 'purchase' || line === 'purchases') {
                 return State.PURCHASE;
             }
             break;
         case State.PAYMENT:
-            if (line === 'purchase') {
+            if (line === 'purchase' || line === 'purchases') {
                 return State.PURCHASE;
             }
             break;

--- a/src/parsers/chase-credit-card-parser.ts
+++ b/src/parsers/chase-credit-card-parser.ts
@@ -1,7 +1,7 @@
 import {createParserStateMachine, ParsedTransaction, PdfParse, ParsedOutput} from './base-parser';
 import {flatten2dArray} from '../util/array';
 import {dateFromSlashFormat, dateWithinRange} from '../util/date';
-import {collapseSpaces, sanitizeNumberString} from '../util/string';
+import {sanitizeNumberString} from '../util/string';
 import {readPdf} from '../readPdf';
 
 enum State {
@@ -82,11 +82,7 @@ function performStateAction(currentState: State, line: string, yearPrefix: numbe
 
         const result = processTransactionLine(line, output.startDate, output.endDate);
 
-        if (typeof result === 'string') {
-            if (!!result) {
-                array[array.length - 1].description += '\n' + collapseSpaces(result);
-            }
-        } else {
+        if (typeof result !== 'string') {
             array.push(result);
         }
     }

--- a/src/parsers/chase-credit-card-parser.ts
+++ b/src/parsers/chase-credit-card-parser.ts
@@ -63,8 +63,13 @@ function performStateAction(currentState: State, line: string, yearPrefix: numbe
         const accountNumberMatch = line.match(/account number: .+(\d{4})$/i);
         if (closingDateMatch) {
             const [, startDateString, endDateString] = closingDateMatch;
-            output.startDate = dateFromSlashFormat(startDateString, yearPrefix);
-            output.endDate = dateFromSlashFormat(endDateString, yearPrefix);
+            const startDate = dateFromSlashFormat(startDateString, yearPrefix);
+            const endDate = dateFromSlashFormat(endDateString, yearPrefix);
+            // Chase statements sometimes include transactions a few days outside of the statement range.
+            startDate.setDate( startDate.getDate() - 3 );
+            endDate.setDate( endDate.getDate() + 3 );
+            output.startDate = startDate;
+            output.endDate = endDate;
         } else if (accountNumberMatch && !output.accountSuffix) {
             output.accountSuffix = accountNumberMatch[1];
         }


### PR DESCRIPTION
Hey there @electrovir! 👋 

Thanks for an incredible useful repo.

In processing some Chase credit statements from 2016 on, I ran into several issues either with "Invalid date input" or "Reached end of input before hitting end state" errors.

This PR fixes those errors for Chase statements by:
* Checking for "purchases" in addition to "purchase" when determining state
* Allowing transaction dates to be +/- 3 days of the statement dates (several of my statements had transactions like this)

Additionally, I removed the logic that appends unparsed lines to the description of the previous transaction. This was resulting in huge chunks of non-transaction text (that broke up the table between pages) ending up in the descriptions.

Cheers! 🍻 